### PR TITLE
feat: add support for date-time format using time.Time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,3 +42,28 @@ jobs:
         run: |
           cd tests && ./test.sh
 
+      - name: Run Bindgen Test
+        run: |
+          # we already have a folder named bundle
+          # move it before we get the simulation bundle
+          # TODO change the name
+          mv bundle template-bundle
+
+          # get the latest release
+          RELEASE_INFO=$(curl -s "https://api.github.com/repos/dylibso/xtp-bindgen-test/releases/latest")
+          ASSET_URL=$(echo $RELEASE_INFO | grep -oP '"browser_download_url": "\K(.*bundle.zip)(?=")')
+          if [ -z "$ASSET_URL" ]; then
+            echo "Asset URL not found. Please check the asset name or the repository."
+            exit 1
+          fi
+
+          # download and unzip the bundle
+          curl -L -o bundle.zip "$ASSET_URL"
+          unzip bundle.zip
+          cd bundle/
+
+          # Using ../template-bundle so we test the head template
+          xtp plugin init --schema-file schema.yaml --template ../template-bundle --path exampleplugin --name exampleplugin --feature stub-with-code-samples
+          cd exampleplugin/ && npm run build && cd ..
+          xtp plugin test exampleplugin/dist/plugin.wasm --with test.wasm --mock-host mock.wasm
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,6 @@ jobs:
 
           # Using ../template-bundle so we test the head template
           xtp plugin init --schema-file schema.yaml --template ../template-bundle --path exampleplugin --name exampleplugin --feature stub-with-code-samples
-          cd exampleplugin/ && npm run build && cd ..
+          xtp plugin build --path exampleplugin
           xtp plugin test exampleplugin/dist/plugin.wasm --with test.wasm --mock-host mock.wasm
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,11 @@ import { getContext, helpers, Property } from "@dylibso/xtp-bindgen";
 
 function toGolangType(property: Property): string {
   if (property.$ref) return property.$ref.name;
-
   switch (property.type) {
     case "string":
+      if (property.format === "date-time") {
+        return "time.Time";
+      }
       return "string";
     case "number":
       if (property.format === "float") {

--- a/template/pdk.gen.go.ejs
+++ b/template/pdk.gen.go.ejs
@@ -3,6 +3,8 @@ package main
 
 import (
 	<% if (JSON.stringify(schema).includes("enum")) { %>"errors"<% } %>
+	<% if (JSON.stringify(schema).includes("date-time")) { %>"time"<% } %>
+
 	pdk "github.com/extism/go-pdk"
 )
 

--- a/tests/schemas/fruit.yaml
+++ b/tests/schemas/fruit.yaml
@@ -7,10 +7,6 @@ exports:
       - lang: typescript
         source: |
           console.log('Hello World!')
-      - lang: go
-        source: |- 
-          println("Hello World!")
-          return nil
   - name: topLevelPrimitives
     description: |
       This demonstrates how you can accept or return primtive types.
@@ -119,6 +115,8 @@ schemas:
         description: |
           A datetime object, we will automatically serialize and deserialize
           this for you.
+      - name: writeParams
+        $ref: "#/schemas/WriteParams"
     contentType: application/json
     description: A complex json object
 version: v1-draft


### PR DESCRIPTION
Closes #3 

Go's internal JSON support for time.Time matches our ISO8601-compliance in `xtp-bindgen`. The format it uses is [`time.RFC3339Nano`](https://pkg.go.dev/time#pkg-constants), which supports more precision I think, but still preserves the same details as the JS equivalent. 