### PR TITLE
feat: make generated code more idiomatic to go users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@dylibso/xtp-bindgen": "1.0.0-rc.6",
+        "@dylibso/xtp-bindgen": "1.0.0-rc.7",
         "ejs": "^3.1.10"
       },
       "devDependencies": {
@@ -21,9 +21,9 @@
       }
     },
     "node_modules/@dylibso/xtp-bindgen": {
-      "version": "1.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@dylibso/xtp-bindgen/-/xtp-bindgen-1.0.0-rc.6.tgz",
-      "integrity": "sha512-Sm9eC2tkWtf0rZa51MP7Jm2mtCQI/3z/KM+RC3QxDWOq8f1dmp1fylsKWCVAbGwaIJbrQZI0MusnQ5f9+V4v3A=="
+      "version": "1.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@dylibso/xtp-bindgen/-/xtp-bindgen-1.0.0-rc.7.tgz",
+      "integrity": "sha512-8nMT8xqsC6FYVT2tS4xB3R+VVYAfiu6AceZLlRjfB2SCE5H6YqgX0INU9ZL9IacvFr+mRjEoQZ6B+G4Y/WR9WQ=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.19.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@dylibso/xtp-bindgen": "1.0.0-rc.5",
+        "@dylibso/xtp-bindgen": "1.0.0-rc.6",
         "ejs": "^3.1.10"
       },
       "devDependencies": {
@@ -21,9 +21,9 @@
       }
     },
     "node_modules/@dylibso/xtp-bindgen": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@dylibso/xtp-bindgen/-/xtp-bindgen-1.0.0-rc.5.tgz",
-      "integrity": "sha512-F+s0XA5NeS7q6ikWe7Qou8AsLqYJfCQQbFEpgzWsqIh3YoLF7jcEwgc3Df60FbRocitOf/ZRlCxgaqJlAuD73w=="
+      "version": "1.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@dylibso/xtp-bindgen/-/xtp-bindgen-1.0.0-rc.6.tgz",
+      "integrity": "sha512-Sm9eC2tkWtf0rZa51MP7Jm2mtCQI/3z/KM+RC3QxDWOq8f1dmp1fylsKWCVAbGwaIJbrQZI0MusnQ5f9+V4v3A=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.19.12",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "@dylibso/xtp-bindgen": "1.0.0-rc.5",
+    "@dylibso/xtp-bindgen": "1.0.0-rc.6",
     "ejs": "^3.1.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "@dylibso/xtp-bindgen": "1.0.0-rc.6",
+    "@dylibso/xtp-bindgen": "1.0.0-rc.7",
     "ejs": "^3.1.10"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import ejs from "ejs";
 import { getContext, helpers, Property } from "@dylibso/xtp-bindgen";
 
 function toGolangType(property: Property): string {
-  if (property.$ref) return property.$ref.name;
+  if (property.$ref) return goName(property.$ref.name);
   switch (property.type) {
     case "string":
       if (property.format === "date-time") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,10 @@ function makePublic(s: string) {
   return pub;
 }
 
+function goName(s: string) {
+  return makePublic(helpers.snakeToCamelCase(s));
+}
+
 export function render() {
   const tmpl = Host.inputString();
   const ctx = {
@@ -62,6 +66,7 @@ export function render() {
     toGolangType,
     pointerToGolangType,
     makePublic,
+    goName,
   };
 
   const output = ejs.render(tmpl, ctx);

--- a/template/main.go.ejs
+++ b/template/main.go.ejs
@@ -12,7 +12,7 @@ package main
 // And returns <%- toGolangType(ex.output) %> (<%- formatCommentLine(ex.output.description) %>)
 <% } -%>
 <% -%>
-func <%- ex.name %>(<%- ex.input ? `input ${toGolangType(ex.input)}` : null %>) <%- ex.output ? `(${toGolangType(ex.output)}, error)` : "error" %> {
+func <%- goName(ex.name) %>(<%- ex.input ? `input ${toGolangType(ex.input)}` : null %>) <%- ex.output ? `(${toGolangType(ex.output)}, error)` : "error" %> {
 	<% if (featureFlags['stub-with-code-samples'] && codeSamples(ex, 'go').length > 0) { -%>
 		<%- codeSamples(ex, 'go')[0].source %>
 	<% } else { -%>

--- a/template/pdk.gen.go.ejs
+++ b/template/pdk.gen.go.ejs
@@ -100,7 +100,7 @@ func _<%- goName(ex.name) %>() int32 {
 		<% if (schema.properties.length > 0) { %>
 	
 	// <%- formatCommentBlock(schema.description, "// ") %>
-	type <%- schema.name %> struct {
+	type <%- goName(schema.name) %> struct {
 		<% schema.properties.forEach(p => { -%>
 		<% if (p.description) { -%>
 		// <%- formatCommentBlock(p.description, "// ") %>

--- a/template/pdk.gen.go.ejs
+++ b/template/pdk.gen.go.ejs
@@ -10,12 +10,12 @@ import (
 
 <% schema.exports.forEach(ex => { -%>
 //export <%- ex.name %>
-func _<%- ex.name %>() int32 {
+func _<%- goName(ex.name) %>() int32 {
 	var err error
 	_ = err
   <% if (ex.input) { -%>
     <% if (ex.input.contentType === 'application/json') { -%>
-			pdk.Log(pdk.LogDebug, "<%- ex.name %>: getting JSON input")
+			pdk.Log(pdk.LogDebug, "<%- goName(ex.name) %>: getting JSON input")
 			var input <%- toGolangType(ex.input) %>
 			err = pdk.InputJSON(&input)
 			if err != nil {
@@ -24,30 +24,30 @@ func _<%- ex.name %>() int32 {
 			}
     <% } else if (ex.input.type === 'string') { -%>
       <% if (ex.input.$ref && ex.input.$ref.enum) { -%>
-			pdk.Log(pdk.LogDebug, "<%- ex.name %>: getting enum string input")
-      input, err := stringTo<%- ex.input.$ref.name %>(pdk.InputString())
+			pdk.Log(pdk.LogDebug, "<%- goName(ex.name) %>: getting enum string input")
+      input, err := stringTo<%- goName(ex.input.$ref.name) %>(pdk.InputString())
       if err != nil {
         pdk.SetError(err)
         return -1
       }
 			<% } else { -%>
-			pdk.Log(pdk.LogDebug, "<%- ex.name %>: getting string input")
+			pdk.Log(pdk.LogDebug, "<%- goName(ex.name) %>: getting string input")
 			input := pdk.InputString()
 			<% } %>
     <% } else { -%>
-			pdk.Log(pdk.LogDebug, "<%- ex.name %>: getting bytes input")
+			pdk.Log(pdk.LogDebug, "<%- goName(ex.name) %>: getting bytes input")
       input := pdk.Input()
     <% } -%>
 
-		pdk.Log(pdk.LogDebug, "<%- ex.name %>: calling implementation function")
+		pdk.Log(pdk.LogDebug, "<%- goName(ex.name) %>: calling implementation function")
     <% if (ex.output) { -%>
-      output, err := <%- ex.name %>(input)
+      output, err := <%- goName(ex.name) %>(input)
 			if err != nil {
 				pdk.SetError(err)
 				return -1
 			}
     <% } else { -%>
-      err = <%- ex.name %>(input)
+      err = <%- goName(ex.name) %>(input)
 			if err != nil {
 				pdk.SetError(err)
 				return -1
@@ -55,9 +55,9 @@ func _<%- ex.name %>() int32 {
     <% } -%>
   <% } else { -%>
     <% if (ex.output) { -%>
-      output, err := <%- ex.name %>()
+      output, err := <%- goName(ex.name) %>()
     <% } else { -%>
-      err = <%- ex.name %>()
+      err = <%- goName(ex.name) %>()
     <% } -%>
 		if err != nil {
 			pdk.SetError(err)
@@ -67,22 +67,22 @@ func _<%- ex.name %>() int32 {
 
   <% if (ex.output) { -%>
     <% if (ex.output.contentType === 'application/json') { -%>
-			pdk.Log(pdk.LogDebug, "<%- ex.name %>: setting JSON output")
+			pdk.Log(pdk.LogDebug, "<%- goName(ex.name) %>: setting JSON output")
 			err = pdk.OutputJSON(output)
 			if err != nil {
 				pdk.SetError(err)
 				return -1
 			}
     <% } else if (ex.output.type === 'string') { -%>
-			pdk.Log(pdk.LogDebug, "<%- ex.name %>: setting string output")
+			pdk.Log(pdk.LogDebug, "<%- goName(ex.name) %>: setting string output")
       pdk.OutputString(output)
     <% } else { -%>
-			pdk.Log(pdk.LogDebug, "<%- ex.name %>: setting bytes output")
+			pdk.Log(pdk.LogDebug, "<%- goName(ex.name) %>: setting bytes output")
       pdk.Output(output)
     <% } -%>
   <% } -%>
 
-	pdk.Log(pdk.LogDebug, "<%- ex.name %>: returning")
+	pdk.Log(pdk.LogDebug, "<%- goName(ex.name) %>: returning")
   return 0
 }
 
@@ -91,7 +91,7 @@ func _<%- ex.name %>() int32 {
 <% if (schema.imports.length > 0) { %>
 	<% Object.values(schema.imports).forEach(im => { %>
 		//go:wasmimport extism:host/user <%- im.name %>
-		func _<%- im.name %>(<%- im.input ? "uint64" : null %>) <%- im.output ? "uint64" : null %>
+		func _<%- goName(im.name) %>(<%- im.input ? "uint64" : null %>) <%- im.output ? "uint64" : null %>
 	<% }) %>
 
 	<% } %>
@@ -105,23 +105,23 @@ func _<%- ex.name %>() int32 {
 		<% if (p.description) { -%>
 		// <%- formatCommentBlock(p.description, "// ") %>
 		<% } -%>
-		<%- makePublic(p.name) %> <%- p.nullable ? pointerToGolangType(p) : toGolangType(p) %> `json:"<%- p.name %>"`
+		<%- goName(p.name) %> <%- p.nullable ? pointerToGolangType(p) : toGolangType(p) %> `json:"<%- p.name %>"`
 		<% }) %>
 	}
 		<% } else if (schema.enum) { %>
 	
 	// <%- formatCommentLine(schema.description) %>
-	type <%- makePublic(schema.name) %> string
+	type <%- goName(schema.name) %> string
 	const (
 		<% schema.enum.forEach((variant, i) => { -%>
-			<%- `${makePublic(schema.name)}${makePublic(variant)} ${makePublic(schema.name)} = "${variant}"` %>
+			<%- `${goName(schema.name)}${goName(variant)} ${goName(schema.name)} = "${variant}"` %>
 		<% }) -%>
 	)
 
-	func (v <%- makePublic(schema.name) %>) String() string {
+	func (v <%- goName(schema.name) %>) String() string {
 		switch (v) {
 		<% schema.enum.forEach((variant) => { -%>
-		case <%- `${makePublic(schema.name)}${makePublic(variant)}` %>:
+		case <%- `${goName(schema.name)}${goName(variant)}` %>:
 			return `<%- variant %>`
 		<% }) -%>
 		default: 
@@ -129,14 +129,14 @@ func _<%- ex.name %>() int32 {
 		}
 	}
 
-	func stringTo<%- makePublic(schema.name) %>(s string) (<%- makePublic(schema.name) %>, error) {
+	func stringTo<%- goName(schema.name) %>(s string) (<%- goName(schema.name) %>, error) {
 		switch (s) {
 		<% schema.enum.forEach((variant) => { -%>
 		case `<%- variant %>`:
-			return <%- `${makePublic(schema.name)}${makePublic(variant)}` %>, nil
+			return <%- `${goName(schema.name)}${goName(variant)}` %>, nil
 		<% }) -%>
 		default:
-			return <%- makePublic(schema.name) %>(""), errors.New("unable to convert string to <%- `${makePublic(schema.name)}` %>")
+			return <%- goName(schema.name) %>(""), errors.New("unable to convert string to <%- `${goName(schema.name)}` %>")
 		}
 	}
 
@@ -146,14 +146,14 @@ func _<%- ex.name %>() int32 {
 
 <% schema.imports.forEach(imp => { %>
 	<% if (hasComment(imp)) -%>
-	// <%- makePublic(imp.name) %> <%- formatCommentBlock(imp.description, "// ") %>
+	// <%- goName(imp.name) %> <%- formatCommentBlock(imp.description, "// ") %>
 	<% if (hasComment(imp.input)) { -%>
 	// It takes input of <%- toGolangType(imp.input) %> (<%- formatCommentLine(imp.input.description) %>)
 	<% } -%>
 	<% if (hasComment(imp.output)) { -%>
 	// And it returns an output <%- toGolangType(imp.output) %> (<%- formatCommentLine(imp.output.description) %>)
 	<% } -%>
-	func <%- makePublic(imp.name) %>(<%- imp.input ? `input ${toGolangType(imp.input)}` : null %>) <%- imp.output ? `(${pointerToGolangType(imp.output)}, error)` : "error" %> {
+	func <%- goName(imp.name) %>(<%- imp.input ? `input ${toGolangType(imp.input)}` : null %>) <%- imp.output ? `(${pointerToGolangType(imp.output)}, error)` : "error" %> {
 		var err error
 		_ = err
 	<% if (imp.input) { -%>
@@ -172,9 +172,9 @@ func _<%- ex.name %>() int32 {
 		mem := pdk.AllocateBytes(input)
 		<% } -%>
 
-		<% if (imp.output) { -%>offs :=<% } -%> _<%- imp.name %>(mem.Offset())
+		<% if (imp.output) { -%>offs :=<% } -%> _<%- goName(imp.name) %>(mem.Offset())
 	<% } else { -%>
-		<% if (imp.output) { -%>offs :=<% } -%> _<%- imp.name %>()
+		<% if (imp.output) { -%>offs :=<% } -%> _<%- goName(imp.name) %>()
 	<% } -%>
 	
 	<% if (imp.output) { -%>


### PR DESCRIPTION
Convert any end-user facing identifier to a more Go-friendly option, using the latest helpers in `xtp-bindgen`. e.g.: 

For this schema portion:

```yaml
snake_case_func_name:
    description: This is a function that uses snake case in the name
    input:
      type: string
      contentType: text/plain; charset=utf-8
      description: A string passed into plugin input
    output:
      $ref: "#/components/schemas/some_value"
      contentType: application/json
#...
components:
  schemas:
    some_value:
      properties:
        a_string:
          type: string
          description: a string
```

We now produce:  

```go
// This is a function that uses snake case in the name
// It takes string as input (A string passed into plugin input)
// And returns SomeValue ()
func SnakeCaseFuncName(input string) (SomeValue, error) {
	// TODO: fill out your implementation here
	panic("Function not implemented.")
}
```