### PR TITLE
chore: update xtp-bindgen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@dylibso/xtp-bindgen": "1.0.0-rc.7",
+        "@dylibso/xtp-bindgen": "1.0.0-rc.8",
         "ejs": "^3.1.10"
       },
       "devDependencies": {
@@ -21,9 +21,9 @@
       }
     },
     "node_modules/@dylibso/xtp-bindgen": {
-      "version": "1.0.0-rc.7",
-      "resolved": "https://registry.npmjs.org/@dylibso/xtp-bindgen/-/xtp-bindgen-1.0.0-rc.7.tgz",
-      "integrity": "sha512-8nMT8xqsC6FYVT2tS4xB3R+VVYAfiu6AceZLlRjfB2SCE5H6YqgX0INU9ZL9IacvFr+mRjEoQZ6B+G4Y/WR9WQ=="
+      "version": "1.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@dylibso/xtp-bindgen/-/xtp-bindgen-1.0.0-rc.8.tgz",
+      "integrity": "sha512-9PVXiNa9xL+LNdn0wTY7cUzYiB44RIO/HNIXBeZZSyaA2Tc0rJl97TPcNPpJvQhNUwQVfjWDxCRXYULpUKf/nw=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.19.12",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "@dylibso/xtp-bindgen": "1.0.0-rc.7",
+    "@dylibso/xtp-bindgen": "1.0.0-rc.8",
     "ejs": "^3.1.10"
   }
 }


### PR DESCRIPTION
There is a bug in xtp-bindgen rc7 or lower see https://github.com/dylibso/xtp-bindgen/pull/9