### PR TITLE
Add errors package to base imports

### DIFF
--- a/template/main.go.ejs
+++ b/template/main.go.ejs
@@ -2,6 +2,8 @@
 // ./pdk.gen.go contains the domain types from the host where your plugin will run.
 package main
 
+import "errors"
+
 <% schema.exports.forEach(ex => { %>
 <% if (hasComment(ex)) -%>	
 // <%- formatCommentBlock(ex.description, "// ") %>

--- a/template/prepare.sh
+++ b/template/prepare.sh
@@ -68,3 +68,5 @@ if ! (command_exists tinygo); then
   echo "    pacman -S extra/tinygo"
   echo ""
 fi
+
+go install golang.org/x/tools/cmd/goimports@latest

--- a/template/xtp.toml.ejs
+++ b/template/xtp.toml.ejs
@@ -11,7 +11,7 @@ name = "<%- project.name %>"
 build = "mkdir -p dist && tinygo build -target wasi -o dist/plugin.wasm ."
 
 # xtp plugin init runs this script to format the code
-format = "go fmt"
+format = "go fmt && go mod tidy"
 
 # xtp plugin init runs this script before running the format script
 prepare = "sh prepare.sh && go get ./..."

--- a/template/xtp.toml.ejs
+++ b/template/xtp.toml.ejs
@@ -11,7 +11,7 @@ name = "<%- project.name %>"
 build = "mkdir -p dist && tinygo build -target wasi -o dist/plugin.wasm ."
 
 # xtp plugin init runs this script to format the code
-format = "go fmt && go mod tidy"
+format = "go fmt && go mod tidy && goimports -w main.go"
 
 # xtp plugin init runs this script before running the format script
 prepare = "sh prepare.sh && go get ./..."


### PR DESCRIPTION
I believe `go fmt` will clean this up if it's not used right? Needed for examples.