### PR TITLE
fix: use tinygo reactor module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,10 +40,9 @@ jobs:
       - name: Install TinyGo
         uses: acifani/setup-tinygo@v1.1.0
         with:
-          tinygo-version: 0.33.0
+          tinygo-version: 0.34.0
           binaryen-version: "116"
           
-
       - name: Run test script
         run: |
           cd tests && ./test.sh

--- a/template/pdk.gen.go.ejs
+++ b/template/pdk.gen.go.ejs
@@ -197,6 +197,3 @@ func _<%- goName(ex.name) %>() int32 {
 	<% } %>
 	}
 <% }) %>
-
-// Note: leave this in place, as the Go compiler will find the `export` function as the entrypoint.
-func main() {}

--- a/template/prepare.sh
+++ b/template/prepare.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
+set -eou pipefail
 
 # Function to check if a command exists
 command_exists () {
   command -v "$1" >/dev/null 2>&1
+}
+
+# Function to compare version numbers
+version_gt() {
+  test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" != "$1"
 }
 
 missing_deps=0
@@ -10,7 +16,7 @@ missing_deps=0
 # Check for Go
 if ! (command_exists go); then
   missing_deps=1
-  echo "❌ Go (supported version between 1.18 - 1.22) is not installed."
+  echo "❌ Go (supported version between 1.18 - 1.23) is not installed."
   echo ""
   echo "To install Go, visit the official download page:"
   echo "👉 https://go.dev/dl/"
@@ -26,27 +32,29 @@ if ! (command_exists go); then
   echo "🔹 Arch Linux:"
   echo "    sudo pacman -S go"
   echo ""
+  echo "🔹 Windows:"
+  echo "    scoop install go"
+  echo ""
 fi
 
-# Check for the right version of Go, needed by TinyGo (supports go 1.18 - 1.22)
+# Check for the right version of Go, needed by TinyGo (supports go 1.18 - 1.23)
 if (command_exists go); then
   compat=0
-  for v in `seq 18 22`; do
+  for v in `seq 18 23`; do
     if (go version | grep -q "go1.$v"); then
       compat=1
     fi
   done
 
   if [ $compat -eq 0 ]; then
-    echo "❌ Supported Go version is not installed. Must be Go 1.18 - 1.22."
+    echo "❌ Supported Go version is not installed. Must be Go 1.18 - 1.23."
     echo ""
   fi
 fi
 
-
 ARCH=$(arch)
 
-# Check for TinyGo
+# Check for TinyGo and its version
 if ! (command_exists tinygo); then
   missing_deps=1
   echo "❌ TinyGo is not installed."
@@ -61,12 +69,24 @@ if ! (command_exists tinygo); then
   echo "    brew install tinygo"
   echo ""
   echo "🔹 Ubuntu/Debian:"
-  echo "    wget https://github.com/tinygo-org/tinygo/releases/download/v0.31.2/tinygo_0.31.2_$ARCH.deb"
-  echo "    sudo dpkg -i tinygo_0.31.2_$ARCH.deb"
+  echo "    wget https://github.com/tinygo-org/tinygo/releases/download/v0.34.0/tinygo_0.34.0_$ARCH.deb"
+  echo "    sudo dpkg -i tinygo_0.34.0_$ARCH.deb"
   echo ""
   echo "🔹 Arch Linux:"
   echo "    pacman -S extra/tinygo"
   echo ""
+  echo "🔹 Windows:"
+  echo "    scoop install tinygo"
+  echo ""
+else
+  # Check TinyGo version
+  tinygo_version=$(tinygo version | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -n1)
+  if ! version_gt "$tinygo_version" "0.34.0"; then
+    missing_deps=1
+    echo "❌ TinyGo version must be greater than 0.34.0 (current version: $tinygo_version)"
+    echo "Please update TinyGo to a newer version."
+    echo ""
+  fi
 fi
 
 go install golang.org/x/tools/cmd/goimports@latest

--- a/template/xtp.toml.ejs
+++ b/template/xtp.toml.ejs
@@ -14,4 +14,4 @@ build = "mkdir -p dist && tinygo build -buildmode c-shared -target wasip1 -o dis
 format = "go fmt && go mod tidy && goimports -w main.go"
 
 # xtp plugin init runs this script before running the format script
-prepare = "sh prepare.sh && go get ./..."
+prepare = "bash prepare.sh && go get ./..."

--- a/template/xtp.toml.ejs
+++ b/template/xtp.toml.ejs
@@ -8,7 +8,7 @@ name = "<%- project.name %>"
 
 [scripts]
 # xtp plugin build runs this script to generate the wasm file
-build = "mkdir -p dist && tinygo build -target wasi -o dist/plugin.wasm ."
+build = "mkdir -p dist && tinygo build -buildmode c-shared -target wasip1 -o dist/plugin.wasm ."
 
 # xtp plugin init runs this script to format the code
 format = "go fmt && go mod tidy && goimports -w main.go"

--- a/tests/schemas/fruit.yaml
+++ b/tests/schemas/fruit.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://xtp.dylibso.com/assets/wasm/schema.json
 exports:
   voidFunc:
     description: "This demonstrates how you can create an export with\nno inputs or
@@ -72,7 +73,6 @@ imports:
       description: the raw byte values at key
   kv_write:
     description: kvwrite
-    contentType: application/json
     input:
       contentType: application/json
       "$ref": "#/components/schemas/WriteParams"

--- a/tests/schemas/random.yaml
+++ b/tests/schemas/random.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://xtp.dylibso.com/assets/wasm/schema.json
 ---
 version: v1-draft
 exports:
@@ -293,7 +294,6 @@ imports:
       contentType: application/json
       description: Nested reference input
     output:
-      type: object
       contentType: application/json
       description: Nested output structure
       "$ref": "#/components/schemas/NestedObject"


### PR DESCRIPTION
since TinyGo now officially supports reactor modules, we should switch to it:

https://github.com/tinygo-org/tinygo/pull/4451

This make sure xtp plugins can use wasi features out of the box without resorting to hacks, the only downside is that we have to force people to upgrade to TinyGo version 0.34.0